### PR TITLE
Supporting new security delete return values

### DIFF
--- a/src/main/java/com/damienwesterman/defensedrill/mvc/DefenseDrillMvcApplication.java
+++ b/src/main/java/com/damienwesterman/defensedrill/mvc/DefenseDrillMvcApplication.java
@@ -33,10 +33,6 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 @SpringBootApplication
 @EnableDiscoveryClient
 public class DefenseDrillMvcApplication {
-	// TODO: Finish changing all input to textarea like in drill_form
-	// TODO: give some text wrapping in the html, maybe up to 3 lines?
-	// TODO: Double check all other input forms to make sure they are looking fine (login)
-	// TODO: make sure instructions have 2 mandatory steps
 	// TODO: research if it is possible to allow the steps to be rearranged
 	// TODO: 101 problems to start
 	public static void main(String[] args) {

--- a/src/main/java/com/damienwesterman/defensedrill/mvc/DefenseDrillMvcApplication.java
+++ b/src/main/java/com/damienwesterman/defensedrill/mvc/DefenseDrillMvcApplication.java
@@ -33,6 +33,12 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 @SpringBootApplication
 @EnableDiscoveryClient
 public class DefenseDrillMvcApplication {
+	// TODO: Finish changing all input to textarea like in drill_form
+	// TODO: give some text wrapping in the html, maybe up to 3 lines?
+	// TODO: Double check all other input forms to make sure they are looking fine (login)
+	// TODO: make sure instructions have 2 mandatory steps
+	// TODO: research if it is possible to allow the steps to be rearranged
+	// TODO: 101 problems to start
 	public static void main(String[] args) {
 		SpringApplication.run(DefenseDrillMvcApplication.class, args);
 	}

--- a/src/main/java/com/damienwesterman/defensedrill/mvc/DefenseDrillMvcApplication.java
+++ b/src/main/java/com/damienwesterman/defensedrill/mvc/DefenseDrillMvcApplication.java
@@ -33,8 +33,6 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 @SpringBootApplication
 @EnableDiscoveryClient
 public class DefenseDrillMvcApplication {
-	// TODO: research if it is possible to allow the steps to be rearranged
-	// TODO: 101 problems to start
 	public static void main(String[] args) {
 		SpringApplication.run(DefenseDrillMvcApplication.class, args);
 	}

--- a/src/main/java/com/damienwesterman/defensedrill/mvc/web/controller/HtmxDrillController.java
+++ b/src/main/java/com/damienwesterman/defensedrill/mvc/web/controller/HtmxDrillController.java
@@ -306,8 +306,9 @@ public class HtmxDrillController {
         model.addAttribute("descriptionText", instructions.getDescription());
         model.addAttribute("videoIdText", instructions.getVideoId());
         model.addAttribute("firstStep", instructions.getSteps().get(0));
-        model.addAttribute("stepsListAfterFirst", 
-            instructions.getSteps().subList(1, instructions.getSteps().size()));
+        model.addAttribute("secondStep", instructions.getSteps().get(1));
+        model.addAttribute("stepsListAfterSecond", 
+            instructions.getSteps().subList(2, instructions.getSteps().size()));
         model.addAttribute("postEndpoint",
             "/htmx/drill/" + drillId + "/instructions/modify/" + instructionsDescription
                 + "?startingEndpoint=" + startingEndpoint);

--- a/src/main/java/com/damienwesterman/defensedrill/mvc/web/controller/HtmxUserController.java
+++ b/src/main/java/com/damienwesterman/defensedrill/mvc/web/controller/HtmxUserController.java
@@ -285,8 +285,12 @@ public class HtmxUserController {
 
     @PostMapping("/delete/{id}")
     public String deleteOneUser(Model model, @PathVariable Long id) {
-        apiService.delete(id);
-        model.addAttribute("successMessage", "User Successfully Deleted!");
+        var response = apiService.delete(id);
+        if (response.hasError()) {
+            model.addAttribute("errorMessage", response.getError().toString());
+        } else {
+            model.addAttribute("successMessage", "User Successfully Deleted!");
+        }
         return deleteUsersList(model);
     }
 }

--- a/src/main/resources/public/main.css
+++ b/src/main/resources/public/main.css
@@ -323,12 +323,13 @@ nav a:hover {
     border-radius: 4px;
     font-size: 1rem;
     resize: vertical;
+    line-height: 1rem;
     min-height: 1rem;
     height: 1rem;
 }
 
 .form-input[maxlength] {
-    max-height: 8rem; /* Adjust as needed */
+    max-height: 4rem;
 }
 
 .form-input:focus {

--- a/src/main/resources/public/main.css
+++ b/src/main/resources/public/main.css
@@ -318,6 +318,7 @@ nav a:hover {
 }
 
 .form-input {
+    font-family: inherit;
     padding: 0.5rem;
     border: 1px solid #ccc;
     border-radius: 4px;

--- a/src/main/resources/public/main.css
+++ b/src/main/resources/public/main.css
@@ -322,6 +322,13 @@ nav a:hover {
     border: 1px solid #ccc;
     border-radius: 4px;
     font-size: 1rem;
+    resize: vertical;
+    min-height: 1rem;
+    height: 1rem;
+}
+
+.form-input[maxlength] {
+    max-height: 8rem; /* Adjust as needed */
 }
 
 .form-input:focus {

--- a/src/main/resources/public/main.js
+++ b/src/main/resources/public/main.js
@@ -13,10 +13,35 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 /*
- * Dynamically resize textarea inputs as the user types
+ * Make sure when a user presses "Enter" in a textarea, it submits the form.
+ * Also dynamically resize textarea inputs as the user types.
+ * All textarea tags should be used inside an HTMX request inside of tab_with_window.html.
  */
-function resizeTextarea(textarea) {
-    if (textarea.scrollHeight > textarea.clientHeight) {
-        textarea.style.height = textarea.scrollHeight + "px";
-    }
+function setupTextareas() {
+    document.querySelectorAll("textarea").forEach(textarea => {
+        if (!textarea.dataset.htmxListenerAdded) { 
+            textarea.dataset.htmxListenerAdded = "true";
+
+            // Auto-resize on input
+            textarea.addEventListener("input", function () {
+                if (textarea.scrollHeight > textarea.clientHeight) {
+                    textarea.style.height = textarea.scrollHeight + "px";
+                }
+            });
+
+            // Submit form on Enter (unless Shift+Enter is used)
+            textarea.addEventListener("keydown", function (event) {
+                if (event.key === "Enter" && !event.shiftKey) {
+                    event.preventDefault(); // Prevent new line
+                    const form = this.closest("form");
+                    if (form) {
+                        htmx.trigger(form, "submit");
+                    }
+                }
+            });
+        }
+    });
 }
+document.addEventListener("DOMContentLoaded", setupTextareas);
+document.addEventListener("htmx:afterSwap", setupTextareas);
+

--- a/src/main/resources/public/main.js
+++ b/src/main/resources/public/main.js
@@ -29,9 +29,9 @@ function setupTextareas() {
                 }
             });
 
-            // Submit form on Enter (unless Shift+Enter is used)
+            // Submit form on Enter
             textarea.addEventListener("keydown", function (event) {
-                if (event.key === "Enter" && !event.shiftKey) {
+                if (event.key === "Enter") {
                     event.preventDefault(); // Prevent new line
                     const form = this.closest("form");
                     if (form) {

--- a/src/main/resources/public/main.js
+++ b/src/main/resources/public/main.js
@@ -1,12 +1,22 @@
+/*
+ * To be used with tab_with_window.html to highlight the currently selected tab.
+ */
 document.addEventListener("DOMContentLoaded", () => {
     const sideNavLinks = document.querySelectorAll("#sideNav a");
 
     sideNavLinks.forEach(link => {
         link.addEventListener("click", () => {
-            // Remove the 'active' class from all links
             sideNavLinks.forEach(link => link.classList.remove("active"));
-            // Add the 'active' class to the clicked link
             link.classList.add("active");
         });
     });
 });
+
+/*
+ * Dynamically resize textarea inputs as the user types
+ */
+function resizeTextarea(textarea) {
+    if (textarea.scrollHeight > textarea.clientHeight) {
+        textarea.style.height = textarea.scrollHeight + "px";
+    }
+}

--- a/src/main/resources/templates/layouts/htmx/abstract_category_form.html
+++ b/src/main/resources/templates/layouts/htmx/abstract_category_form.html
@@ -40,7 +40,6 @@
                         <textarea
                             th:text="${nameText}"
                             id="name"
-                            type="text"
                             name="name"
                             placeholder="Enter name..."
                             class="form-input"
@@ -55,7 +54,6 @@
                         <textarea
                             th:text="${descriptionText}"
                             id="description"
-                            type="text"
                             name="description"
                             placeholder="Enter description..."
                             class="form-input"

--- a/src/main/resources/templates/layouts/htmx/abstract_category_form.html
+++ b/src/main/resources/templates/layouts/htmx/abstract_category_form.html
@@ -37,8 +37,8 @@
 
                     <div class="form-group">
                         <label for="name">Name:</label>
-                        <input
-                            th:value="${nameText}"
+                        <textarea
+                            th:text="${nameText}"
                             id="name"
                             type="text"
                             name="name"
@@ -47,13 +47,13 @@
                             required
                             minlength="1"
                             maxlength="255"
-                            title="Name must be between 1 and 255 characters." />
+                            title="Name must be between 1 and 255 characters."></textarea>
                     </div>
 
                     <div class="form-group">
                         <label for="description">Description:</label>
-                        <input
-                            th:value="${descriptionText}"
+                        <textarea
+                            th:text="${descriptionText}"
                             id="description"
                             type="text"
                             name="description"
@@ -62,7 +62,7 @@
                             required
                             minlength="1"
                             maxlength="511"
-                            title="Description must be between 1 and 511 characters." />
+                            title="Description must be between 1 and 511 characters."></textarea>
                     </div>
 
                     <!-- Sub-window for selecting drills -->

--- a/src/main/resources/templates/layouts/htmx/drill_form.html
+++ b/src/main/resources/templates/layouts/htmx/drill_form.html
@@ -26,6 +26,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
     <head>
         <script src="https://unpkg.com/htmx.org@1.8.0"></script>
+        <script src="/main.js"></script>
     </head>
     <body>
         <!--/* To be used in conjunction with tab_with_window.html, hence hx-target="#contentArea" */-->
@@ -52,7 +53,8 @@
                             required
                             minlength="1"
                             maxlength="255"
-                            title="Name must be between 1 and 255 characters."></textarea>
+                            title="Name must be between 1 and 255 characters."
+                            oninput="resizeTextarea(this)"></textarea>
                     </div>
 
                     <h3>You can add instructions on the next page.</h3>

--- a/src/main/resources/templates/layouts/htmx/drill_form.html
+++ b/src/main/resources/templates/layouts/htmx/drill_form.html
@@ -43,17 +43,16 @@
 
                     <div class="form-group">
                         <label for="name">Name:</label>
-                        <input
-                            th:value="${nameText}"
+                        <textarea
+                            th:text="${nameText}"
                             id="name"
-                            type="text"
                             name="name"
                             placeholder="Enter name..."
                             class="form-input"
                             required
                             minlength="1"
                             maxlength="255"
-                            title="Name must be between 1 and 255 characters." />
+                            title="Name must be between 1 and 255 characters."></textarea>
                     </div>
 
                     <h3>You can add instructions on the next page.</h3>

--- a/src/main/resources/templates/layouts/htmx/drill_form.html
+++ b/src/main/resources/templates/layouts/htmx/drill_form.html
@@ -26,7 +26,6 @@
 <html xmlns:th="http://www.thymeleaf.org">
     <head>
         <script src="https://unpkg.com/htmx.org@1.8.0"></script>
-        <script src="/main.js"></script>
     </head>
     <body>
         <!--/* To be used in conjunction with tab_with_window.html, hence hx-target="#contentArea" */-->
@@ -53,8 +52,7 @@
                             required
                             minlength="1"
                             maxlength="255"
-                            title="Name must be between 1 and 255 characters."
-                            oninput="resizeTextarea(this)"></textarea>
+                            title="Name must be between 1 and 255 characters."></textarea>
                     </div>
 
                     <h3>You can add instructions on the next page.</h3>

--- a/src/main/resources/templates/layouts/htmx/instructions_add_step.html
+++ b/src/main/resources/templates/layouts/htmx/instructions_add_step.html
@@ -15,16 +15,15 @@
         <div th:fragment="instructionsAddStep">
             <div class="steps-container">
                 <li class="step">
-                    <input
-                        th:value="${descriptionText}"
-                        type="text"
+                    <textarea
+                        th:text="${descriptionText}"
                         name="steps"
                         placeholder="Enter step..."
                         class="form-input step-input"
                         required
                         minlength="1"
                         maxlength="255"
-                        title="Step must be between 1 and 255 characters." />
+                        title="Step must be between 1 and 255 characters."></textarea>
                         <button
                             type="button"
                             class="button delete-step-button"

--- a/src/main/resources/templates/layouts/htmx/instructions_form.html
+++ b/src/main/resources/templates/layouts/htmx/instructions_form.html
@@ -6,10 +6,11 @@
 * postEndpoint      Y           String              HTMX endpoint to submit the instructions form to
 * descriptionText   N           String              Existing instructions description
 * videoIdText       N           String              Existing jellyfin video ID
-* firstStep         N           String              Existing FIRST steps from the list of steps
-* stepsListAfterFirst
-*                   N           List<String>        Existing list of steps AFTER the first step
-*                                                   (DO NOT include the first step!!)
+* firstStep         N           String              Existing FIRST step from the list of steps
+* secondStep        N           String              Existing SECOND step from the list of steps
+* stepsListAfterSecond
+*                   N           List<String>        Existing list of steps AFTER the second step
+*                                                   (DO NOT include the second step!!)
 * drillId           Y           Long                ID fo the drill the instructions belong to
 * backEndpoint      Y           String              The original HTMX endpoint that started this chain
 *                                                   screens, used to pass along to the next screen if the
@@ -79,7 +80,21 @@
                                         title="Step must be between 1 and 255 characters."></textarea>
                                 </li>
                             </div>
-                            <div th:each="oneStep : ${stepsListAfterFirst}">
+                            <div class="steps-container">
+                                <!-- Second Step, always required (so that Spring does not separate on the comma), cannot be deleted -->
+                                <li class="step">
+                                    <textarea
+                                        th:text="${secondStep}"
+                                        name="steps"
+                                        placeholder="Enter step..."
+                                        class="form-input step-input"
+                                        required
+                                        minlength="1"
+                                        maxlength="255"
+                                        title="Step must be between 1 and 255 characters."></textarea>
+                                </li>
+                            </div>
+                            <div th:each="oneStep : ${stepsListAfterSecond}">
                                 <div th:replace="~{layouts/htmx/instructions_add_step :: instructionsAddStep(descriptionText=${oneStep})}"></div>
                             </div>
                             <div id="additionalSteps"></div>

--- a/src/main/resources/templates/layouts/htmx/instructions_form.html
+++ b/src/main/resources/templates/layouts/htmx/instructions_form.html
@@ -37,30 +37,28 @@
                     <!-- Description Field -->
                     <div class="form-group">
                         <label for="description">Description:</label>
-                        <input
-                            th:value="${descriptionText}"
+                        <textarea
+                            th:text="${descriptionText}"
                             id="description"
-                            type="text"
                             name="description"
                             placeholder="Enter description..."
                             class="form-input"
                             required
                             minlength="1"
                             maxlength="511"
-                            title="Description must be between 1 and 511 characters." />
+                            title="Description must be between 1 and 511 characters."></textarea>
                     </div>
 
                     <!-- Video ID Field -->
                     <div class="form-group">
                         <label for="videoId">Video ID (optional):</label>
-                        <input
-                            th:value="${videoIdText}"
+                        <textarea
+                            th:text="${videoIdText}"
                             id="videoId"
-                            type="text"
                             name="videoId"
                             placeholder="Enter Jellyfin video ID..."
                             class="form-input"
-                            title="Copy/paste the corresponding Jellyfin Item ID." />
+                            title="Copy/paste the corresponding Jellyfin Item ID."></textarea>
                     </div>
 
                     <!-- Steps Field -->
@@ -70,16 +68,15 @@
                             <div class="steps-container">
                                 <!-- First Step, always required, cannot be deleted -->
                                 <li class="step">
-                                    <input
-                                        th:value="${firstStep}"
-                                        type="text"
+                                    <textarea
+                                        th:text="${firstStep}"
                                         name="steps"
                                         placeholder="Enter step..."
                                         class="form-input step-input"
                                         required
                                         minlength="1"
                                         maxlength="255"
-                                        title="Step must be between 1 and 255 characters." />
+                                        title="Step must be between 1 and 255 characters."></textarea>
                                 </li>
                             </div>
                             <div th:each="oneStep : ${stepsListAfterFirst}">


### PR DESCRIPTION
Supporting changes to the DefenseDrillSecurity API change in [PR#8](https://github.com/DamienWesterman/DefenseDrillSecurity/pull/8)
After using the web app for a couple of weeks, the following small features and bugs were discovered and need addressing:
- [ ] Make a list of illegal characters, namely '#'
   - It was discovered that if '#' exists in the name of an instruction, it would end up in a URI, which has it's own URI meaning
   - NOTE: This will be addressed in another set of PRs for all microservices. The real issue here is improper URL encoding. All custom strings being used in URLs need to be encoded using `URLEncoding.encode(customString, "UTF-8");`
- [x] Update the User delete htmx endpoint
   - This is to support changes to the DefenseDrillSecurity API change in [PR#8](https://github.com/DamienWesterman/DefenseDrillSecurity/pull/8)
- [x] Make sure instructions have at least two mandatory steps
   - It was discovered that if there is only one step and it has a comma, then Spring would separate the list by the comma
   - If there is more than one step, then the comma is not used as the delimiter
- [ ] Allow the user to rearrange the steps in an instruction
   - This is desired for convenience, but given the first two mandatory steps and the use of HTMX, this may not be possible
   - NOTE: It was found that this is not plausible and would require notable rework and JavaScript
- [x] Change most of the text entry fields so there is some text wrapping
   - Just a convenience thing for users
   - While doing instruction steps (which can get long), I had to side scroll in the text box a lot